### PR TITLE
Fix drag-and-drop not working correctly in MacOS

### DIFF
--- a/src/style/browser.css
+++ b/src/style/browser.css
@@ -51,7 +51,6 @@ html.list-colors body .color-skyblue .icon svg {
 /* * Body  * */
 body {
   background-color: var(--bg-primary) !important;
-  -webkit-app-region: drag;
 }
 html {
   overflow: hidden;

--- a/src/win.js
+++ b/src/win.js
@@ -44,7 +44,7 @@ class Win {
       icon: is.linux && file.icon,
       show: false,
       title: app.getName(),
-      titleBarStyle: "hiddenInset",
+      titleBarStyle: "default",
       webPreferences: {
         nodeIntegration: false,
         enableRemoteModule: true,


### PR DESCRIPTION
- The entire body was set as a "drag" area and "hiddenInset" titlebar was used
- This caused the window to move when trying to drag-and-drop a task/list
- Remove "drag" area in body CSS and use default titlebar. Both of these only had any impact on MacOS anyway and this brings the UI style more in line with Linux.


Close OSS-7