### PR TITLE
Improve Nix package and sync to latest version & Nix Flake support!

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
 # TODO: add shell support (with electron and node_modules symlink)
-pkgs.callPackage ./release.nix { }
+pkgs.callPackage ./release.nix {
+  electron = electron_22;
+};
 

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,6 @@
 
 # TODO: add shell support (with electron and node_modules symlink)
 pkgs.callPackage ./release.nix {
-  electron = electron_22;
-};
+  electron = pkgs.electron_22;
+}
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678898370,
+        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Kuro's Flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem 
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          packages.default = import ./default.nix { inherit pkgs; };
+          # TODO: add shell support (with electron and node_modules symlink)
+        }
+      );
+}

--- a/yarn.nix
+++ b/yarn.nix
@@ -26,6 +26,14 @@
       };
     }
     {
+      name = "_babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
+      path = fetchurl {
+        name = "_babel_helper_validator_identifier___helper_validator_identifier_7.19.1.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz";
+        sha512 = "awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==";
+      };
+    }
+    {
       name = "_babel_highlight___highlight_7.17.12.tgz";
       path = fetchurl {
         name = "_babel_highlight___highlight_7.17.12.tgz";
@@ -74,19 +82,27 @@
       };
     }
     {
-      name = "_eslint_eslintrc___eslintrc_1.3.0.tgz";
+      name = "_eslint_eslintrc___eslintrc_1.4.1.tgz";
       path = fetchurl {
-        name = "_eslint_eslintrc___eslintrc_1.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz";
-        sha512 = "UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==";
+        name = "_eslint_eslintrc___eslintrc_1.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz";
+        sha512 = "XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==";
       };
     }
     {
-      name = "_humanwhocodes_config_array___config_array_0.9.5.tgz";
+      name = "_humanwhocodes_config_array___config_array_0.11.8.tgz";
       path = fetchurl {
-        name = "_humanwhocodes_config_array___config_array_0.9.5.tgz";
-        url  = "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz";
-        sha512 = "ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==";
+        name = "_humanwhocodes_config_array___config_array_0.11.8.tgz";
+        url  = "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz";
+        sha512 = "UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==";
+      };
+    }
+    {
+      name = "_humanwhocodes_module_importer___module_importer_1.0.1.tgz";
+      path = fetchurl {
+        name = "_humanwhocodes_module_importer___module_importer_1.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz";
+        sha512 = "bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==";
       };
     }
     {
@@ -570,6 +586,14 @@
       };
     }
     {
+      name = "_types_semver___semver_7.3.13.tgz";
+      path = fetchurl {
+        name = "_types_semver___semver_7.3.13.tgz";
+        url  = "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz";
+        sha512 = "21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==";
+      };
+    }
+    {
       name = "_types_verror___verror_1.10.5.tgz";
       path = fetchurl {
         name = "_types_verror___verror_1.10.5.tgz";
@@ -602,67 +626,67 @@
       };
     }
     {
-      name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.31.0.tgz";
+      name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.31.0.tgz";
-        sha512 = "VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==";
+        name = "_typescript_eslint_eslint_plugin___eslint_plugin_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz";
+        sha512 = "alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==";
       };
     }
     {
-      name = "_typescript_eslint_parser___parser_5.31.0.tgz";
+      name = "_typescript_eslint_parser___parser_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_parser___parser_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.31.0.tgz";
-        sha512 = "UStjQiZ9OFTFReTrN+iGrC6O/ko9LVDhreEK5S3edmXgR396JGq7CoX2TWIptqt/ESzU2iRKXAHfSF2WJFcWHw==";
+        name = "_typescript_eslint_parser___parser_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.53.0.tgz";
+        sha512 = "MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==";
       };
     }
     {
-      name = "_typescript_eslint_scope_manager___scope_manager_5.31.0.tgz";
+      name = "_typescript_eslint_scope_manager___scope_manager_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_scope_manager___scope_manager_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz";
-        sha512 = "8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==";
+        name = "_typescript_eslint_scope_manager___scope_manager_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz";
+        sha512 = "Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==";
       };
     }
     {
-      name = "_typescript_eslint_type_utils___type_utils_5.31.0.tgz";
+      name = "_typescript_eslint_type_utils___type_utils_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_type_utils___type_utils_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.31.0.tgz";
-        sha512 = "7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==";
+        name = "_typescript_eslint_type_utils___type_utils_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz";
+        sha512 = "HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==";
       };
     }
     {
-      name = "_typescript_eslint_types___types_5.31.0.tgz";
+      name = "_typescript_eslint_types___types_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_types___types_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.31.0.tgz";
-        sha512 = "/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==";
+        name = "_typescript_eslint_types___types_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.53.0.tgz";
+        sha512 = "5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==";
       };
     }
     {
-      name = "_typescript_eslint_typescript_estree___typescript_estree_5.31.0.tgz";
+      name = "_typescript_eslint_typescript_estree___typescript_estree_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_typescript_estree___typescript_estree_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz";
-        sha512 = "3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==";
+        name = "_typescript_eslint_typescript_estree___typescript_estree_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz";
+        sha512 = "eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==";
       };
     }
     {
-      name = "_typescript_eslint_utils___utils_5.31.0.tgz";
+      name = "_typescript_eslint_utils___utils_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_utils___utils_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.31.0.tgz";
-        sha512 = "kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==";
+        name = "_typescript_eslint_utils___utils_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.53.0.tgz";
+        sha512 = "VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==";
       };
     }
     {
-      name = "_typescript_eslint_visitor_keys___visitor_keys_5.31.0.tgz";
+      name = "_typescript_eslint_visitor_keys___visitor_keys_5.53.0.tgz";
       path = fetchurl {
-        name = "_typescript_eslint_visitor_keys___visitor_keys_5.31.0.tgz";
-        url  = "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz";
-        sha512 = "ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==";
+        name = "_typescript_eslint_visitor_keys___visitor_keys_5.53.0.tgz";
+        url  = "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz";
+        sha512 = "JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==";
       };
     }
     {
@@ -679,6 +703,14 @@
         name = "acorn___acorn_8.7.1.tgz";
         url  = "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz";
         sha512 = "Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==";
+      };
+    }
+    {
+      name = "acorn___acorn_8.8.2.tgz";
+      path = fetchurl {
+        name = "acorn___acorn_8.8.2.tgz";
+        url  = "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz";
+        sha512 = "xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==";
       };
     }
     {
@@ -1154,14 +1186,6 @@
       };
     }
     {
-      name = "builtins___builtins_4.1.0.tgz";
-      path = fetchurl {
-        name = "builtins___builtins_4.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/builtins/-/builtins-4.1.0.tgz";
-        sha512 = "1bPRZQtmKaO6h7qV1YHXNtr6nCK28k0Zo95KM4dXfILcZZwoHJBN1m3lfLv9LPkcOZlrSr+J1bzMaZFO98Yq0w==";
-      };
-    }
-    {
       name = "builtins___builtins_5.0.1.tgz";
       path = fetchurl {
         name = "builtins___builtins_5.0.1.tgz";
@@ -1210,11 +1234,11 @@
       };
     }
     {
-      name = "camelcase_keys___camelcase_keys_7.0.2.tgz";
+      name = "camelcase_keys___camelcase_keys_8.0.2.tgz";
       path = fetchurl {
-        name = "camelcase_keys___camelcase_keys_7.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-7.0.2.tgz";
-        sha512 = "Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==";
+        name = "camelcase_keys___camelcase_keys_8.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-8.0.2.tgz";
+        sha512 = "qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==";
       };
     }
     {
@@ -1242,11 +1266,11 @@
       };
     }
     {
-      name = "camelcase___camelcase_6.3.0.tgz";
+      name = "camelcase___camelcase_7.0.1.tgz";
       path = fetchurl {
-        name = "camelcase___camelcase_6.3.0.tgz";
-        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz";
-        sha512 = "Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==";
+        name = "camelcase___camelcase_7.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz";
+        sha512 = "xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==";
       };
     }
     {
@@ -1303,6 +1327,14 @@
         name = "ci_info___ci_info_3.3.2.tgz";
         url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz";
         sha512 = "xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==";
+      };
+    }
+    {
+      name = "ci_info___ci_info_3.8.0.tgz";
+      path = fetchurl {
+        name = "ci_info___ci_info_3.8.0.tgz";
+        url  = "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz";
+        sha512 = "eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==";
       };
     }
     {
@@ -1434,11 +1466,11 @@
       };
     }
     {
-      name = "commondir___commondir_1.0.1.tgz";
+      name = "common_path_prefix___common_path_prefix_3.0.0.tgz";
       path = fetchurl {
-        name = "commondir___commondir_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz";
-        sha512 = "W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==";
+        name = "common_path_prefix___common_path_prefix_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz";
+        sha512 = "QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==";
       };
     }
     {
@@ -1503,6 +1535,14 @@
         name = "cosmiconfig___cosmiconfig_7.0.1.tgz";
         url  = "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz";
         sha512 = "a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==";
+      };
+    }
+    {
+      name = "cosmiconfig___cosmiconfig_7.1.0.tgz";
+      path = fetchurl {
+        name = "cosmiconfig___cosmiconfig_7.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz";
+        sha512 = "AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==";
       };
     }
     {
@@ -1594,11 +1634,11 @@
       };
     }
     {
-      name = "decamelize___decamelize_5.0.1.tgz";
+      name = "decamelize___decamelize_6.0.0.tgz";
       path = fetchurl {
-        name = "decamelize___decamelize_5.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz";
-        sha512 = "VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==";
+        name = "decamelize___decamelize_6.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/decamelize/-/decamelize-6.0.0.tgz";
+        sha512 = "Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==";
       };
     }
     {
@@ -2018,19 +2058,19 @@
       };
     }
     {
-      name = "eslint_config_xo_typescript___eslint_config_xo_typescript_0.51.1.tgz";
+      name = "eslint_config_xo_typescript___eslint_config_xo_typescript_0.55.1.tgz";
       path = fetchurl {
-        name = "eslint_config_xo_typescript___eslint_config_xo_typescript_0.51.1.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.51.1.tgz";
-        sha512 = "bqUYpPLylgOtuueawFJnLFX/t2W6shKYR+IwbwBZhw9ivr2sLd+8I2vLfKDDzxMrHzij8bkdVoRoDLRvugQoXg==";
+        name = "eslint_config_xo_typescript___eslint_config_xo_typescript_0.55.1.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.55.1.tgz";
+        sha512 = "iXua+7n9fOp7LzGzvXlcZG0w6cdtscjASGTrAHMj0Rn9voayxF2oRoMIK1QS6ZJb4fMVEQZdU2D6gTKmWhcCQQ==";
       };
     }
     {
-      name = "eslint_config_xo___eslint_config_xo_0.41.0.tgz";
+      name = "eslint_config_xo___eslint_config_xo_0.43.1.tgz";
       path = fetchurl {
-        name = "eslint_config_xo___eslint_config_xo_0.41.0.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.41.0.tgz";
-        sha512 = "cyTc182COQVdalOi5105h0Cw/Qb52IRGyIZLmUICIauANm9Upmv81UEsuFkdKnvwr4NtU95qjdk3g4/kNspA6g==";
+        name = "eslint_config_xo___eslint_config_xo_0.43.1.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.43.1.tgz";
+        sha512 = "azv1L2PysRA0NkZOgbndUpN+581L7wPqkgJOgxxw3hxwXAbJgD6Hqb/SjHRiACifXt/AvxCzE/jIKFAlI7XjvQ==";
       };
     }
     {
@@ -2098,11 +2138,11 @@
       };
     }
     {
-      name = "eslint_plugin_n___eslint_plugin_n_15.2.3.tgz";
+      name = "eslint_plugin_n___eslint_plugin_n_15.6.1.tgz";
       path = fetchurl {
-        name = "eslint_plugin_n___eslint_plugin_n_15.2.3.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-15.2.3.tgz";
-        sha512 = "H+KC7U5R+3IWTeRnACm/4wlqLvS1Q7M6t7BGhn89qXDkZan8HTAEv3ouIONA0ifDwc2YzPFmyPzHuNLddNK4jw==";
+        name = "eslint_plugin_n___eslint_plugin_n_15.6.1.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-15.6.1.tgz";
+        sha512 = "R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==";
       };
     }
     {
@@ -2114,19 +2154,19 @@
       };
     }
     {
-      name = "eslint_plugin_prettier___eslint_plugin_prettier_4.0.0.tgz";
+      name = "eslint_plugin_prettier___eslint_plugin_prettier_4.2.1.tgz";
       path = fetchurl {
-        name = "eslint_plugin_prettier___eslint_plugin_prettier_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz";
-        sha512 = "98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==";
+        name = "eslint_plugin_prettier___eslint_plugin_prettier_4.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz";
+        sha512 = "f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==";
       };
     }
     {
-      name = "eslint_plugin_unicorn___eslint_plugin_unicorn_42.0.0.tgz";
+      name = "eslint_plugin_unicorn___eslint_plugin_unicorn_44.0.2.tgz";
       path = fetchurl {
-        name = "eslint_plugin_unicorn___eslint_plugin_unicorn_42.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz";
-        sha512 = "ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==";
+        name = "eslint_plugin_unicorn___eslint_plugin_unicorn_44.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz";
+        sha512 = "GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==";
       };
     }
     {
@@ -2194,19 +2234,19 @@
       };
     }
     {
-      name = "eslint___eslint_8.18.0.tgz";
+      name = "eslint___eslint_8.34.0.tgz";
       path = fetchurl {
-        name = "eslint___eslint_8.18.0.tgz";
-        url  = "https://registry.yarnpkg.com/eslint/-/eslint-8.18.0.tgz";
-        sha512 = "As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==";
+        name = "eslint___eslint_8.34.0.tgz";
+        url  = "https://registry.yarnpkg.com/eslint/-/eslint-8.34.0.tgz";
+        sha512 = "1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==";
       };
     }
     {
-      name = "esm_utils___esm_utils_4.0.0.tgz";
+      name = "esm_utils___esm_utils_4.1.1.tgz";
       path = fetchurl {
-        name = "esm_utils___esm_utils_4.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/esm-utils/-/esm-utils-4.0.0.tgz";
-        sha512 = "1x5H25/8BQWV94T8+KRb1gcSdVQ3g+8P0NikggAujVaurUa0cOoR+UO8ie3y29iQO70HjNA93c9ie+qqI/8zzw==";
+        name = "esm_utils___esm_utils_4.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/esm-utils/-/esm-utils-4.1.1.tgz";
+        sha512 = "cTy4OQgEP/yc7RY3s6EgwMGZ10gAPhCLE9FcrQ6/5bhf37o9PZCFSjzQR1tYb4GaKAEMaW1UmDcMZR13H4p6LQ==";
       };
     }
     {
@@ -2215,6 +2255,14 @@
         name = "espree___espree_9.3.2.tgz";
         url  = "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz";
         sha512 = "D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==";
+      };
+    }
+    {
+      name = "espree___espree_9.4.1.tgz";
+      path = fetchurl {
+        name = "espree___espree_9.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz";
+        sha512 = "XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==";
       };
     }
     {
@@ -2450,11 +2498,11 @@
       };
     }
     {
-      name = "find_cache_dir___find_cache_dir_3.3.2.tgz";
+      name = "find_cache_dir___find_cache_dir_4.0.0.tgz";
       path = fetchurl {
-        name = "find_cache_dir___find_cache_dir_3.3.2.tgz";
-        url  = "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz";
-        sha512 = "wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==";
+        name = "find_cache_dir___find_cache_dir_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-4.0.0.tgz";
+        sha512 = "9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==";
       };
     }
     {
@@ -2618,14 +2666,6 @@
       };
     }
     {
-      name = "functional_red_black_tree___functional_red_black_tree_1.0.1.tgz";
-      path = fetchurl {
-        name = "functional_red_black_tree___functional_red_black_tree_1.0.1.tgz";
-        url  = "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz";
-        sha512 = "dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==";
-      };
-    }
-    {
       name = "functions_have_names___functions_have_names_1.2.3.tgz";
       path = fetchurl {
         name = "functions_have_names___functions_have_names_1.2.3.tgz";
@@ -2778,11 +2818,11 @@
       };
     }
     {
-      name = "globals___globals_13.15.0.tgz";
+      name = "globals___globals_13.20.0.tgz";
       path = fetchurl {
-        name = "globals___globals_13.15.0.tgz";
-        url  = "https://registry.yarnpkg.com/globals/-/globals-13.15.0.tgz";
-        sha512 = "bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==";
+        name = "globals___globals_13.20.0.tgz";
+        url  = "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz";
+        sha512 = "Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==";
       };
     }
     {
@@ -2802,11 +2842,11 @@
       };
     }
     {
-      name = "globby___globby_13.1.2.tgz";
+      name = "globby___globby_13.1.3.tgz";
       path = fetchurl {
-        name = "globby___globby_13.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz";
-        sha512 = "LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==";
+        name = "globby___globby_13.1.3.tgz";
+        url  = "https://registry.yarnpkg.com/globby/-/globby-13.1.3.tgz";
+        sha512 = "8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==";
       };
     }
     {
@@ -2847,6 +2887,14 @@
         name = "graceful_readlink___graceful_readlink_1.0.1.tgz";
         url  = "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz";
         sha512 = "8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==";
+      };
+    }
+    {
+      name = "grapheme_splitter___grapheme_splitter_1.0.4.tgz";
+      path = fetchurl {
+        name = "grapheme_splitter___grapheme_splitter_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz";
+        sha512 = "bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==";
       };
     }
     {
@@ -2959,6 +3007,14 @@
         name = "hosted_git_info___hosted_git_info_4.1.0.tgz";
         url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz";
         sha512 = "kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==";
+      };
+    }
+    {
+      name = "hosted_git_info___hosted_git_info_5.2.1.tgz";
+      path = fetchurl {
+        name = "hosted_git_info___hosted_git_info_5.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.2.1.tgz";
+        sha512 = "xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==";
       };
     }
     {
@@ -3082,11 +3138,11 @@
       };
     }
     {
-      name = "import_meta_resolve___import_meta_resolve_1.1.1.tgz";
+      name = "import_meta_resolve___import_meta_resolve_2.2.0.tgz";
       path = fetchurl {
-        name = "import_meta_resolve___import_meta_resolve_1.1.1.tgz";
-        url  = "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-1.1.1.tgz";
-        sha512 = "JiTuIvVyPaUg11eTrNDx5bgQ/yMKMZffc7YSjvQeSMXy58DO2SQ8BtAf3xteZvmzvjYh14wnqNjL8XVeDy2o9A==";
+        name = "import_meta_resolve___import_meta_resolve_2.2.0.tgz";
+        url  = "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.2.0.tgz";
+        sha512 = "CpPOtiCHxP9HdtDM5F45tNiAe66Cqlv3f5uHoJjt+KlaLrUh9/Wz9vepADZ78SlqEo62aDWZtj9ydMGXV+CPnw==";
       };
     }
     {
@@ -3210,11 +3266,11 @@
       };
     }
     {
-      name = "is_builtin_module___is_builtin_module_3.1.0.tgz";
+      name = "is_builtin_module___is_builtin_module_3.2.1.tgz";
       path = fetchurl {
-        name = "is_builtin_module___is_builtin_module_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.1.0.tgz";
-        sha512 = "OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==";
+        name = "is_builtin_module___is_builtin_module_3.2.1.tgz";
+        url  = "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz";
+        sha512 = "BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==";
       };
     }
     {
@@ -3231,6 +3287,14 @@
         name = "is_ci___is_ci_3.0.1.tgz";
         url  = "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz";
         sha512 = "ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==";
+      };
+    }
+    {
+      name = "is_core_module___is_core_module_2.11.0.tgz";
+      path = fetchurl {
+        name = "is_core_module___is_core_module_2.11.0.tgz";
+        url  = "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz";
+        sha512 = "RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==";
       };
     }
     {
@@ -3383,6 +3447,14 @@
         name = "is_path_inside___is_path_inside_1.0.1.tgz";
         url  = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz";
         sha512 = "qhsCR/Esx4U4hg/9I19OVUAJkGWtjRYHMRgUMZE2TDdj+Ag+kttZanLupfddNyglzz50cUlmWzUaI37GDfNx/g==";
+      };
+    }
+    {
+      name = "is_path_inside___is_path_inside_3.0.3.tgz";
+      path = fetchurl {
+        name = "is_path_inside___is_path_inside_3.0.3.tgz";
+        url  = "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz";
+        sha512 = "Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==";
       };
     }
     {
@@ -3591,6 +3663,14 @@
         name = "jpeg_js___jpeg_js_0.4.4.tgz";
         url  = "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz";
         sha512 = "WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==";
+      };
+    }
+    {
+      name = "js_sdsl___js_sdsl_4.3.0.tgz";
+      path = fetchurl {
+        name = "js_sdsl___js_sdsl_4.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz";
+        sha512 = "mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==";
       };
     }
     {
@@ -3954,11 +4034,11 @@
       };
     }
     {
-      name = "make_dir___make_dir_3.1.0.tgz";
+      name = "lru_cache___lru_cache_7.17.0.tgz";
       path = fetchurl {
-        name = "make_dir___make_dir_3.1.0.tgz";
-        url  = "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz";
-        sha512 = "g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==";
+        name = "lru_cache___lru_cache_7.17.0.tgz";
+        url  = "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.17.0.tgz";
+        sha512 = "zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==";
       };
     }
     {
@@ -4002,11 +4082,11 @@
       };
     }
     {
-      name = "meow___meow_10.1.2.tgz";
+      name = "meow___meow_11.0.0.tgz";
       path = fetchurl {
-        name = "meow___meow_10.1.2.tgz";
-        url  = "https://registry.yarnpkg.com/meow/-/meow-10.1.2.tgz";
-        sha512 = "zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==";
+        name = "meow___meow_11.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/meow/-/meow-11.0.0.tgz";
+        sha512 = "Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==";
       };
     }
     {
@@ -4250,6 +4330,14 @@
       };
     }
     {
+      name = "natural_compare_lite___natural_compare_lite_1.4.0.tgz";
+      path = fetchurl {
+        name = "natural_compare_lite___natural_compare_lite_1.4.0.tgz";
+        url  = "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz";
+        sha512 = "Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==";
+      };
+    }
+    {
       name = "natural_compare___natural_compare_1.4.0.tgz";
       path = fetchurl {
         name = "natural_compare___natural_compare_1.4.0.tgz";
@@ -4279,6 +4367,14 @@
         name = "normalize_package_data___normalize_package_data_3.0.3.tgz";
         url  = "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz";
         sha512 = "p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==";
+      };
+    }
+    {
+      name = "normalize_package_data___normalize_package_data_4.0.1.tgz";
+      path = fetchurl {
+        name = "normalize_package_data___normalize_package_data_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-4.0.1.tgz";
+        sha512 = "EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==";
       };
     }
     {
@@ -4762,19 +4858,19 @@
       };
     }
     {
-      name = "pkg_dir___pkg_dir_4.2.0.tgz";
-      path = fetchurl {
-        name = "pkg_dir___pkg_dir_4.2.0.tgz";
-        url  = "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz";
-        sha512 = "HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==";
-      };
-    }
-    {
       name = "pkg_dir___pkg_dir_5.0.0.tgz";
       path = fetchurl {
         name = "pkg_dir___pkg_dir_5.0.0.tgz";
         url  = "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz";
         sha512 = "NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==";
+      };
+    }
+    {
+      name = "pkg_dir___pkg_dir_7.0.0.tgz";
+      path = fetchurl {
+        name = "pkg_dir___pkg_dir_7.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-7.0.0.tgz";
+        sha512 = "Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==";
       };
     }
     {
@@ -4906,11 +5002,11 @@
       };
     }
     {
-      name = "prettier___prettier_2.7.1.tgz";
+      name = "prettier___prettier_2.8.4.tgz";
       path = fetchurl {
-        name = "prettier___prettier_2.7.1.tgz";
-        url  = "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz";
-        sha512 = "ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==";
+        name = "prettier___prettier_2.8.4.tgz";
+        url  = "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz";
+        sha512 = "vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==";
       };
     }
     {
@@ -5018,6 +5114,14 @@
       };
     }
     {
+      name = "quick_lru___quick_lru_6.1.1.tgz";
+      path = fetchurl {
+        name = "quick_lru___quick_lru_6.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/quick-lru/-/quick-lru-6.1.1.tgz";
+        sha512 = "S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==";
+      };
+    }
+    {
       name = "read_config_file___read_config_file_6.2.0.tgz";
       path = fetchurl {
         name = "read_config_file___read_config_file_6.2.0.tgz";
@@ -5042,11 +5146,11 @@
       };
     }
     {
-      name = "read_pkg_up___read_pkg_up_8.0.0.tgz";
+      name = "read_pkg_up___read_pkg_up_9.1.0.tgz";
       path = fetchurl {
-        name = "read_pkg_up___read_pkg_up_8.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-8.0.0.tgz";
-        sha512 = "snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==";
+        name = "read_pkg_up___read_pkg_up_9.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-9.1.0.tgz";
+        sha512 = "vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==";
       };
     }
     {
@@ -5066,11 +5170,11 @@
       };
     }
     {
-      name = "read_pkg___read_pkg_6.0.0.tgz";
+      name = "read_pkg___read_pkg_7.1.0.tgz";
       path = fetchurl {
-        name = "read_pkg___read_pkg_6.0.0.tgz";
-        url  = "https://registry.yarnpkg.com/read-pkg/-/read-pkg-6.0.0.tgz";
-        sha512 = "X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==";
+        name = "read_pkg___read_pkg_7.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/read-pkg/-/read-pkg-7.1.0.tgz";
+        sha512 = "5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==";
       };
     }
     {
@@ -5330,6 +5434,14 @@
       };
     }
     {
+      name = "semver___semver_7.3.8.tgz";
+      path = fetchurl {
+        name = "semver___semver_7.3.8.tgz";
+        url  = "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz";
+        sha512 = "NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==";
+      };
+    }
+    {
       name = "semver___semver_7.0.0.tgz";
       path = fetchurl {
         name = "semver___semver_7.0.0.tgz";
@@ -5407,6 +5519,14 @@
         name = "slash___slash_4.0.0.tgz";
         url  = "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz";
         sha512 = "3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==";
+      };
+    }
+    {
+      name = "slash___slash_5.0.0.tgz";
+      path = fetchurl {
+        name = "slash___slash_5.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/slash/-/slash-5.0.0.tgz";
+        sha512 = "n6KkmvKS0623igEVj3FF0OZs1gYYJ0o0Hj939yc1fyxl2xt+xYpLnzJB6xBSqOfV9ZFLEWodBBN/heZJahuIJQ==";
       };
     }
     {
@@ -5946,19 +6066,19 @@
       };
     }
     {
-      name = "type_fest___type_fest_1.4.0.tgz";
-      path = fetchurl {
-        name = "type_fest___type_fest_1.4.0.tgz";
-        url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz";
-        sha512 = "yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==";
-      };
-    }
-    {
       name = "type_fest___type_fest_2.13.1.tgz";
       path = fetchurl {
         name = "type_fest___type_fest_2.13.1.tgz";
         url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.1.tgz";
         sha512 = "hXYyrPFwETT2swFLHeoKtJrvSF/ftG/sA15/8nGaLuaDGfVAaq8DYFpu4yOyV4tzp082WqnTEoMsm3flKMI2FQ==";
+      };
+    }
+    {
+      name = "type_fest___type_fest_2.19.0.tgz";
+      path = fetchurl {
+        name = "type_fest___type_fest_2.19.0.tgz";
+        url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz";
+        sha512 = "RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==";
       };
     }
     {
@@ -5970,6 +6090,14 @@
       };
     }
     {
+      name = "type_fest___type_fest_3.6.0.tgz";
+      path = fetchurl {
+        name = "type_fest___type_fest_3.6.0.tgz";
+        url  = "https://registry.yarnpkg.com/type-fest/-/type-fest-3.6.0.tgz";
+        sha512 = "RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==";
+      };
+    }
+    {
       name = "typedarray___typedarray_0.0.6.tgz";
       path = fetchurl {
         name = "typedarray___typedarray_0.0.6.tgz";
@@ -5978,11 +6106,11 @@
       };
     }
     {
-      name = "typescript___typescript_4.7.4.tgz";
+      name = "typescript___typescript_4.9.5.tgz";
       path = fetchurl {
-        name = "typescript___typescript_4.7.4.tgz";
-        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz";
-        sha512 = "C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==";
+        name = "typescript___typescript_4.9.5.tgz";
+        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz";
+        sha512 = "1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==";
       };
     }
     {
@@ -6242,11 +6370,11 @@
       };
     }
     {
-      name = "xo___xo_0.51.0.tgz";
+      name = "xo___xo_0.53.1.tgz";
       path = fetchurl {
-        name = "xo___xo_0.51.0.tgz";
-        url  = "https://registry.yarnpkg.com/xo/-/xo-0.51.0.tgz";
-        sha512 = "T9VTOsiCzJJZKNBVWbPFCaVdo/TebfXHjzozCSUq1LZnpMUXLzcAyeNOekKG4/b2CvKoCC5jeSQlyylXzAKq6Q==";
+        name = "xo___xo_0.53.1.tgz";
+        url  = "https://registry.yarnpkg.com/xo/-/xo-0.53.1.tgz";
+        sha512 = "/2R8SPehv1UhiIqJ9uSvrAjslcoygICNsUlEb/Zf2V6rMtr7YCoggc6hlt6b/kbncpR989Roqt6AvEO779dFxw==";
       };
     }
     {


### PR DESCRIPTION
Improve Nix package and sync to latest version
Improve suggestion is from https://github.com/NixOS/nixpkgs/pull/211022

And, The Nix mainline has been migrated to the brand-new flake system. So, we now have Flake support!
Most intuitively, we can now just use `nix run` in the project directory to build and run kuro package directly.
There also is `nix develop` for develop shell (Not yet implemented, so now just nothing), and `nix build` command for build package.
If this pull request is merged, We also can use`nix run github:davidsmorais/kuro` to do same things but anywhere with nix.
And I didn't remove `default.nix` so the legacy `nix-build` command is also work.

You can find more here: https://nixos.org/manual/nix/stable/command-ref/experimental-commands.html

Here is also some help for packaging for nix:

For this current package, Nix will independently manage and use the Electron binary provided by itself, so if you update the Electron version, you need to update the Electron provided to the Nix package synchronously(in `default.nix`).

If there is no change in the software architecture related to Electron (also no calls to other things like natively compiled binaries), you need to do these things when syncing versions:

Update the `rev` and the `hash` in the `fetchFromGitHub` method:

The `rev` can be a released version ([like 9.0.0](https://github.com/davidsmorais/kuro/releases/tag/v9.0.0)) or a commit hash ([like `daec9191a69a4e5fae709867f63a479036624a98`](https://github.com/davidsmorais/kuro/commit/daec9191a69a4e5fae709867f63a479036624a98))
The `hash` can be calculated by fetch the tarball of source like this:
```sh
nix flake prefetch https://github.com/davidsmorais/kuro/archive/refs/tags/v9.0.0.tar.gz
```
This will [download the tarball and unpack it](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake-prefetch.html), store it and able to used by flake, and also calculate the **[SRI hash with sha256](https://github.com/NixOS/nixpkgs/issues/191128#issuecomment-1246030466)**.

And we need `yarn.nix` for `mkYarnPackage` to download all yarn packages at build time. You [can use `yarn2nix` for `yarn.nix`](https://nixos.wiki/wiki/Node.js#Packaging_with_yarn2nix):
```sh
yarn2nix > yarn.nix
```
Make sure you have done `yarn install` before do this.

Generally, that's all you have to do,

I know that Nix is ​​not very popular, and it is very different from other Linux distro, I thank you for allowing me to add Nix support to Kuro.

I’m a Chinese and I'm not good at English. So it is difficult for me to write English documents, And that's why I haven't answered your questions in previous pull requests in detail before. I am learning English recently, thank you for your understanding.


<!--

Thank you for taking the time to contribute to Kuro! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/davidsmorais/kuro/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage!

Thank you so much again for all of your time invested in the project!

-->
