### PR TITLE
Removed --edge from snap install command in Readme.md because that will install an outdated version of kuro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Checkout our [Installation Guide](https://github.com/davidsmorais/kuro/wiki/Inst
 Kuro can be found on the [Snap Store](https://snapcraft.io/kuro-desktop/).
 If you have Snap installed on your system you can install Kuro by running
 ```
-sudo snap install kuro-desktop --edge
+sudo snap install kuro-desktop
 ```
 ### AUR
 


### PR DESCRIPTION
Removed --edge from snap install because that will install an outdated version