### PR TITLE
Add: freedesktop metainfo

### DIFF
--- a/flatpak/com.davidmorais.kuro.metainfo.xml
+++ b/flatpak/com.davidmorais.kuro.metainfo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.davidmorais.kuro</id>
+  <name>Kuro</name>
+  <summary>An elegant Microsoft ToDo desktop client</summary>
+  <developer_name>David Morais</developer_name>
+
+  <project_license>MIT</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+
+  <description>
+	<p>Kuro is an unofficial, featureful, open source, community-driven, free Microsoft To-Do app for Linux.</p>
+  </description>
+  
+  <screenshots>
+    <screenshot type="default">
+      <caption>Tasks</caption>
+      <caption xml:lang="ru">Задачи</caption>
+      <image type="source">https://user-images.githubusercontent.com/22729436/221692628-73b21cee-567f-4e48-a91c-3cd8db7b9438.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://github.com/davidsmorais/kuro</url>
+
+  <requires>
+    <control>keyboard</control>
+  </requires>
+  <supports>
+    <control>pointing</control>
+  </supports>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">intense</content_attribute>
+  </content_rating>
+
+  <releases>
+    <release date="2025-08-12" version="9.1.1">
+	  <description>
+	  <p>Bug Fixes 🐞</p>
+	  <ul>
+	  	<li>ToDo URLs will no longer open in Chrome and will keep themselves in app.</li>
+	  </ul>
+	  <p>Features ✨</p>
+	  <ul>
+	  	<li><code>bgDanger</code> and <code>fontColorDanger</code> can now be specified in custom themes to target the danger buttons specifically while keeping fontColorWarning for the rest of the UI text.</li>
+	  </ul>
+	  </description>
+    </release>
+
+	<release date="2025-08-06" version="9.1.0">
+	  <description>
+	  <p>Bug Fixes 🐛</p>
+	  <ul>
+	  	<li>Links are no longer opening in Electron, they should use the OS browser instead now</li>
+		<li>Fix suggestions background in custom theme</li>
+		<li>Fixed the exit keybind not being implemented</li>
+	  </ul>
+	  <p>New Features ✨</p>
+	  <ul>
+	  	<li>Flatpak has arrived 🙌</li>
+	  	<li>New setting/shortcut to invert task position</li>
+		<li>Updated electron from v22 to v37 🤖</li>
+	  </ul>
+	  </description>
+    </release>
+  </releases>
+
+  <update_contact>https://github.com/DUB1401</update_contact>
+  <launchable type="desktop-id">com.davidmorais.kuro.desktop</launchable>
+</component>


### PR DESCRIPTION
Storage metainfo file for Freedesktop in upstream as required in https://github.com/flathub/flathub/pull/7045.
